### PR TITLE
remove double newlines in message body

### DIFF
--- a/announcements/announcements.go
+++ b/announcements/announcements.go
@@ -123,6 +123,6 @@ func formatContents(text string) string {
 	if cutoff == -1 {
 		return text
 	}
-
-	return strings.TrimSpace(text[:cutoff])
+	text = text[:cutoff]
+	return strings.TrimSpace(text)
 }

--- a/announcements/announcements.go
+++ b/announcements/announcements.go
@@ -56,7 +56,7 @@ func Listen(ctx context.Context, im *imap.Dialer, announcements chan<- Announcem
 					continue
 				}
 
-				announcements <- formatAnnouncement(2000, email.Subject, contents)
+				announcements <- formatAnnouncement(1990, email.Subject, contents)
 			}
 
 			// no emails were found, so dont bother removing nothing

--- a/announcements/announcements.go
+++ b/announcements/announcements.go
@@ -115,11 +115,14 @@ func remove(im *imap.Dialer, uids []int) error {
 	return err
 }
 
+var replacer = strings.NewReplacer("\n\n", "\n")
+
 func formatContents(text string) string {
+	text = replacer.Replace(text)
 	cutoff := strings.LastIndex(text, "\\-\\-")
 	if cutoff == -1 {
 		return text
 	}
-	text = text[:cutoff]
-	return strings.TrimSpace(text)
+
+	return strings.TrimSpace(text[:cutoff])
 }

--- a/announcements/announcements_test.go
+++ b/announcements/announcements_test.go
@@ -14,7 +14,7 @@ func Test_formatAnnouncement(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want Announcement
+		want []string
 	}{
 		{
 			name: "no-cutoff",
@@ -23,10 +23,7 @@ func Test_formatAnnouncement(t *testing.T) {
 				subject: "test",
 				body:    "test",
 			},
-			want: Announcement{
-				Subject:  "test",
-				Contents: []string{"test"},
-			},
+			want: []string{"test"},
 		},
 		{
 			name: "cutoff",
@@ -35,10 +32,7 @@ func Test_formatAnnouncement(t *testing.T) {
 				subject: "test",
 				body:    "0.1.2.3.4.5.6.7.8.9",
 			},
-			want: Announcement{
-				Subject:  "test",
-				Contents: []string{"0.1.2.", "3.4.5.6.7.", "8.9"},
-			},
+			want: []string{"0.1.2.", "3.4.5.6.7.", "8.9"},
 		},
 		{
 			name: "cutoff that ends in a dot",
@@ -47,10 +41,7 @@ func Test_formatAnnouncement(t *testing.T) {
 				subject: "test",
 				body:    ".1.2.3.4.5.6.7.",
 			},
-			want: Announcement{
-				Subject:  "test",
-				Contents: []string{".1.2.3.", "4.5.6.7."},
-			},
+			want: []string{".1.2.3.", "4.5.6.7."},
 		},
 		{
 			name: "we cant split it",
@@ -59,32 +50,24 @@ func Test_formatAnnouncement(t *testing.T) {
 				subject: "test",
 				body:    "0123456789",
 			},
-			want: Announcement{
-				Subject:  "test",
-				Contents: []string{"0123456789"},
-			},
+			want: []string{"012345", "6789"},
 		},
 		{
 			name: "with end delimiter",
 			args: args{
-				maxLen:  10,
+				maxLen:  25,
 				subject: "test",
 				body: `Full body test.
 example announcement.
-It has an end delimiter. \-\-
-and then an email.
-`,
+Insert third line.`,
 			},
-			want: Announcement{
-				Subject:  "test",
-				Contents: []string{"Full body test.", "example announcement.", "It has an end delimiter."},
-			},
+			want: []string{"Full body test.\n", "example announcement.\n", "Insert third line."},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := formatAnnouncement(tt.args.maxLen, tt.args.subject, tt.args.body); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("formatAnnouncement() = %q, want %q", got, tt.want)
+			if got := buildContents(tt.args.maxLen, tt.args.subject, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\ngot:\n\t%q\nwant:\n\t%q", got, tt.want)
 			}
 		})
 	}

--- a/announcements/announcements_test.go
+++ b/announcements/announcements_test.go
@@ -1,0 +1,91 @@
+package announcements
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_formatAnnouncement(t *testing.T) {
+	type args struct {
+		maxLen  int
+		subject string
+		body    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Announcement
+	}{
+		{
+			name: "no-cutoff",
+			args: args{
+				maxLen:  100,
+				subject: "test",
+				body:    "test",
+			},
+			want: Announcement{
+				Subject:  "test",
+				Contents: []string{"test"},
+			},
+		},
+		{
+			name: "cutoff",
+			args: args{
+				maxLen:  10,
+				subject: "test",
+				body:    "0.1.2.3.4.5.6.7.8.9",
+			},
+			want: Announcement{
+				Subject:  "test",
+				Contents: []string{"0.1.2.", "3.4.5.6.7.", "8.9"},
+			},
+		},
+		{
+			name: "cutoff that ends in a dot",
+			args: args{
+				maxLen:  11,
+				subject: "test",
+				body:    ".1.2.3.4.5.6.7.",
+			},
+			want: Announcement{
+				Subject:  "test",
+				Contents: []string{".1.2.3.", "4.5.6.7."},
+			},
+		},
+		{
+			name: "we cant split it",
+			args: args{
+				maxLen:  10,
+				subject: "test",
+				body:    "0123456789",
+			},
+			want: Announcement{
+				Subject:  "test",
+				Contents: []string{"0123456789"},
+			},
+		},
+		{
+			name: "with end delimiter",
+			args: args{
+				maxLen:  10,
+				subject: "test",
+				body: `Full body test.
+example announcement.
+It has an end delimiter. \-\-
+and then an email.
+`,
+			},
+			want: Announcement{
+				Subject:  "test",
+				Contents: []string{"Full body test.", "example announcement.", "It has an end delimiter."},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatAnnouncement(tt.args.maxLen, tt.args.subject, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("formatAnnouncement() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"os/signal"
 	"strings"
 	"syscall"
 
 	"github.com/BrianLeishman/go-imap"
-
-	"os"
-	"os/signal"
 
 	"github.com/bwmarrin/lit"
 	"github.com/hhhapz/noncer/announcements"
@@ -96,11 +95,11 @@ func sendWebhook(ctx context.Context, a announcements.Announcement) error {
 	for i := range a.Contents {
 		buf.Reset()
 
-		if i == 0 { // fmt with subject
-			json.NewEncoder(buf).Encode(Webhook{fmt.Sprintf("**%s**\n\n%s", a.Subject, a.Contents[i])})
-		} else {
-			json.NewEncoder(buf).Encode(Webhook{a.Contents[i]})
+		msg := Webhook{a.Contents[i]}
+		if i == 0 {
+			msg = Webhook{fmt.Sprintf("**%s**\n\n%s", a.Subject, a.Contents[i])}
 		}
+		json.NewEncoder(buf).Encode(msg)
 
 		req, err := http.NewRequestWithContext(ctx, "POST", *webhook, buf)
 		req.Header.Set("Content-Type", "application/json")

--- a/main.go
+++ b/main.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/BrianLeishman/go-imap"
 	"io"
 	"net/http"
 	"strings"
 	"syscall"
+
+	"github.com/BrianLeishman/go-imap"
 
 	"os"
 	"os/signal"
@@ -84,7 +85,7 @@ func run(ctx context.Context) error {
 	}()
 
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
 	cancel()
 	return nil


### PR DESCRIPTION
also removes os.Kill from the signal lists, since it can't be catched.